### PR TITLE
修复了未勾选异地模式仍使用远程地址生成二维码的问题

### DIFF
--- a/src/gui/network_config_tab.py
+++ b/src/gui/network_config_tab.py
@@ -296,7 +296,7 @@ class NetworkConfigTab(QWidget):
 
                 # Generate QR code
                 remote_address = self.remote_address_edit.text()
-                if remote_address:
+                if self.enable_remote_checkbox.isChecked():
                     url = client.get_qrcode(f"ws://{remote_address}:{port}")
                     logger.info(f"使用远程地址生成二维码: ws://{remote_address}:{port}")
                 else:


### PR DESCRIPTION
注意到文件 /src/gui/network_config_tab.py 的 299 行粗暴的将**远程地址输入框内是否有字符**作为**是否使用远程地址生成二维码**的条件


已修复
‘‘‘
**old:** 
 299 if remote_ip:


**new:** 
299 if self.enable_remote_checkbox.isChecked():
’’’